### PR TITLE
adapt named and token based voting

### DIFF
--- a/openslides_voting/migrations/0004_motionpolltype.py
+++ b/openslides_voting/migrations/0004_motionpolltype.py
@@ -77,7 +77,7 @@ class Migration(migrations.Migration):
                 ('poll', models.ForeignKey(
                     on_delete=django.db.models.deletion.CASCADE, to='assignments.AssignmentPoll')),
                 ('result_token', models.PositiveIntegerField()),
-                ('proxy_protected', models.BooleanField(default=False)),
+                ('is_dummy', models.BooleanField(default=False)),
             ],
             options={
                 'default_permissions': (),
@@ -112,7 +112,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='motionpollballot',
-            name='proxy_protected',
+            name='is_dummy',
             field=models.BooleanField(default=False),
         ),
         migrations.AlterField(

--- a/openslides_voting/models.py
+++ b/openslides_voting/models.py
@@ -237,7 +237,7 @@ class MotionPollBallot(RESTModelMixin, models.Model, PollBallot):
     delegate = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
     vote = models.CharField(max_length=1, blank=True)
     result_token = models.PositiveIntegerField()
-    proxy_protected = models.BooleanField(default=False)
+    is_dummy = models.BooleanField(default=False)
 
     class Meta:
         default_permissions = ()
@@ -253,7 +253,7 @@ class AssignmentPollBallot(RESTModelMixin, models.Model, PollBallot):
     delegate = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
     vote = JSONField(default={})
     result_token = models.PositiveIntegerField()
-    proxy_protected = models.BooleanField(default=False)
+    is_dummy = models.BooleanField(default=False)
 
     class Meta:
         default_permissions = ()

--- a/openslides_voting/static/js/openslides_voting/site.js
+++ b/openslides_voting/static/js/openslides_voting/site.js
@@ -512,7 +512,8 @@ angular.module('OpenSlidesApp.openslides_voting.site', [
                 return;
             }
 
-            var included = operator.user && _.includes(av.authorized_voters, operator.user.id);
+            var included = operator.user
+                && _.includes(_.keys(av.authorized_voters), operator.user.id.toString());
             // This user is not affected by the current voting.
             if (!included) {
                 Messaging.deleteMessage(messageId);
@@ -587,7 +588,7 @@ angular.module('OpenSlidesApp.openslides_voting.site', [
                 if (!av || !motion || !av.motionPoll || motion.id !== av.motionPoll.motion.id) {
                     return;
                 }
-                if (_.includes(av.authorized_voters, operator.user.id)) {
+                if (_.includes(_.keys(av.authorized_voters), operator.user.id.toString())) {
                     return av.motion_poll_id;
                 }
             },
@@ -613,7 +614,7 @@ angular.module('OpenSlidesApp.openslides_voting.site', [
                 if (!av || !assignment || !av.assignmentPoll || assignment.id !== av.assignmentPoll.assignment.id) {
                     return;
                 }
-                if (_.includes(av.authorized_voters, operator.user.id)) {
+                if (_.includes(_.keys(av.authorized_voters), operator.user.id.toString())) {
                     return av.assignmnt_poll_id;
                 }
             },

--- a/openslides_voting/views.py
+++ b/openslides_voting/views.py
@@ -741,7 +741,7 @@ class AttendanceView(View):
             total_shares['heads'][0] += 1
 
             # Find the authorized voter.
-            auth_voter, _not_used = find_authorized_voter(delegate)
+            auth_voter = find_authorized_voter(delegate)
 
             # If auth_voter is delegate himself set index to 2 (in person) else 3 (represented).
             i = 2 if auth_voter == delegate else 3

--- a/openslides_voting/votecollector/views.py
+++ b/openslides_voting/votecollector/views.py
@@ -237,7 +237,7 @@ class SubmitVotes(ValidationView):
             user = None
             if av.type == 'named_electronic':
                 user = request.user
-                if user.id not in av.authorized_voters.keys():
+                if str(user.id) not in av.authorized_voters:
                     raise ValidationError({'detail': 'The user is not authorized to vote.'})
             else:
                 token_instance = vote['token_instance']
@@ -353,7 +353,7 @@ class SubmitCandidates(ValidationView):
             user = None
             if av.type == 'named_electronic':
                 user = request.user
-                if user.id not in av.authorized_voters.keys():
+                if str(user.id) not in av.authorized_voters:
                     raise ValidationError({'detail': 'The user is not authorized to vote.'})
             else:
                 token_instance = vote['token_instance']
@@ -362,7 +362,6 @@ class SubmitCandidates(ValidationView):
                 # Generate resultToken
                 result_token = ballot.get_next_result_token()
                 result_vote = vote['value']
-
             vc.votes_received += ballot.register_vote(
                 vote['value'],
                 voter=user,


### PR DESCRIPTION
Changes:
- Now a ballot is created for the authorized user even if he **is not** a admitted delegate. This is very important for the both voting modes. But the ballot is marked as "dummy", because it is just a remainder for the one who voted. If he has shares, the he is an admitted delegate, if not, the vote will not be counted. This should not change anything.
- Fixes for the new `authorized_voters` structure
- return just the amount of created ballots (not updated ones), so the `vc.recieved_votes` updates correctly